### PR TITLE
tileGid will overflow when use horizontal flip

### DIFF
--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -746,7 +746,7 @@ void TMXMapInfo::endElement(void *ctx, const char *name)
 
             uint32_t* bufferPtr = reinterpret_cast<uint32_t*>(buffer);
             for(auto gidToken : gidTokens) {
-                auto tileGid = (uint32_t)strtol(gidToken.c_str(), nullptr, 10);
+                auto tileGid = (uint32_t)strtoul(gidToken.c_str(), nullptr, 10);
                 *bufferPtr = tileGid;
                 bufferPtr++;
             }


### PR DESCRIPTION
kTMXTileHorizontalFlag = 0x80000000
when use horizontal flip, gid will bigger chan 0x7FFFFFFF
If the integer value in the string exceeds the "long int" range (overflow or underflow), "strtol" returns the largest (or smallest) integer it can represent.
